### PR TITLE
Fixed keybind being blocked

### DIFF
--- a/addons/main/initKeybinds.sqf
+++ b/addons/main/initKeybinds.sqf
@@ -4,7 +4,5 @@
     // Clear brush if possible
     if (_player call FUNC(canClearBrush)) then {
         _player call FUNC(clearBrush);
-
-        true
     };
 }, {}, [-1, [false, false, false]]] call CBA_fnc_addKeybind; // UNBOUND

--- a/addons/main/initKeybinds.sqf
+++ b/addons/main/initKeybinds.sqf
@@ -4,7 +4,7 @@
     // Clear brush if possible
     if (_player call FUNC(canClearBrush)) then {
         _player call FUNC(clearBrush);
-    };
 
-    true
+        true
+    };
 }, {}, [-1, [false, false, false]]] call CBA_fnc_addKeybind; // UNBOUND


### PR DESCRIPTION
I initially bound `T` to the keybind for clearing brush. I use the same key for lasing targets.
This means that with the current version of the mod it blocks all input from the keybind, regardless if the action was successful or not.

This PR aims to fix what I oversaw with the last PR: Allow players to use the same keybind for multiple different things.